### PR TITLE
FIX & REFACTOR : 유저 이메일, 전화번호 인증 분리. 이메일, 전화번호 인증 로직을 보완하자

### DIFF
--- a/src/main/java/com/sellertool/auth_server/config/security/SecurityConfig.java
+++ b/src/main/java/com/sellertool/auth_server/config/security/SecurityConfig.java
@@ -63,7 +63,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         "/auth/v1/user/**",
                         "/auth/v1/logout",
                         "/auth/v1/refresh",
-                        "/auth/v1/signup"
+                        "/auth/v1/signup",
+                        "/auth/v1/user-info-auth/**"
                 )
                 .permitAll()
                 .anyRequest().denyAll()

--- a/src/main/java/com/sellertool/auth_server/domain/exception/controller/GlobalExceptionHandlerController.java
+++ b/src/main/java/com/sellertool/auth_server/domain/exception/controller/GlobalExceptionHandlerController.java
@@ -20,7 +20,7 @@ public class GlobalExceptionHandlerController {
         log.warn("ERROR STACKTRACE => {}", ex.getStackTrace());
 
         message.setStatus(HttpStatus.BAD_REQUEST);
-        message.setMessage("data_error");
+        message.setMessage("data_invalidation");
         message.setMemo("올바르지 않은 데이터 형식이 존재합니다.");
         return new ResponseEntity<>(message, message.getStatus());
     }

--- a/src/main/java/com/sellertool/auth_server/domain/signup/dto/SignupDto.java
+++ b/src/main/java/com/sellertool/auth_server/domain/signup/dto/SignupDto.java
@@ -24,8 +24,6 @@ public class SignupDto {
     @NotBlank
     private String nickname;
 
-    private String email;
-
     @NotBlank
-    private String phoneNumber;
+    private String email;
 }

--- a/src/main/java/com/sellertool/auth_server/domain/signup/dto/SignupDto.java
+++ b/src/main/java/com/sellertool/auth_server/domain/signup/dto/SignupDto.java
@@ -24,7 +24,6 @@ public class SignupDto {
     @NotBlank
     private String nickname;
 
-    @NotBlank
     private String email;
 
     @NotBlank

--- a/src/main/java/com/sellertool/auth_server/domain/signup/service/SignupBusinessService.java
+++ b/src/main/java/com/sellertool/auth_server/domain/signup/service/SignupBusinessService.java
@@ -39,9 +39,6 @@ public class SignupBusinessService {
     private final WorkspaceService teamService;
     private final WorkspaceMemberService teamMemberService;
 
-    @Value("${phone.auth.token.secret}")
-    private String PHONE_AUTH_JWT_SECRET;
-
     @Value("${email.auth.token.secret}")
     private String EMAIL_AUTH_JWT_SECRET;
 
@@ -65,7 +62,6 @@ public class SignupBusinessService {
         String PASSWORD_CHECK = signupDto.getPasswordCheck();
         String NICKNAME = signupDto.getNickname();
         String EMAIL = signupDto.getEmail();
-        String PHONE_NUMBER = signupDto.getPhoneNumber();
 
         if (userService.isDuplicatedUsername(USERNAME)) {
             throw new ConflictErrorException("아이디 중복 체크를 확인해 주세요.");
@@ -78,63 +74,30 @@ public class SignupBusinessService {
         /*
         이메일 검증
          */
-        if (!(EMAIL == null || EMAIL.isBlank())) {
-            try {
-                DataFormatUtils.checkEmailFormat(EMAIL);    // 이메일 형식 체크
+        try {
+            DataFormatUtils.checkEmailFormat(EMAIL);    // 이메일 형식 체크
 
-                Cookie verifiedToken = WebUtils.getCookie(request, "st_email_auth_vf_token");
+            Cookie verifiedToken = WebUtils.getCookie(request, "st_email_auth_vf_token");
 
-                String emailAuthToken = verifiedToken.getValue();
-                String EMAIL_AUTH_JWT_KEY = EMAIL + EMAIL_AUTH_JWT_SECRET;
+            String emailAuthToken = verifiedToken.getValue();
+            String EMAIL_AUTH_JWT_KEY = EMAIL + EMAIL_AUTH_JWT_SECRET;
 
-                Jwts.parser().setSigningKey(EMAIL_AUTH_JWT_KEY).parseClaimsJws(emailAuthToken).getBody();
+            Jwts.parser().setSigningKey(EMAIL_AUTH_JWT_KEY).parseClaimsJws(emailAuthToken).getBody();
 
-                // st_email_auth_vf_token 제거
-                ResponseCookie emailAuthVerifiedToken = ResponseCookie.from("st_email_auth_vf_token", null)
-                        .domain(CustomCookieInterface.COOKIE_DOMAIN)
-                        .sameSite("Strict")
-                        .path("/")
-                        .maxAge(0)
-                        .build();
-                response.addHeader(HttpHeaders.SET_COOKIE, emailAuthVerifiedToken.toString());
-            } catch (ExpiredJwtException e) {     // 토큰 만료
-                throw new UserInfoAuthJwtException("이메일 인증 토큰이 만료되었습니다.");
-            } catch (NullPointerException e) {   // Phone Auth Number 쿠키가 존재하지 않는다면
-                throw new UserInfoAuthJwtException("이메일 인증을 먼저 진행해주세요.");
-            } catch (Exception e) {
-                throw new UserInfoAuthJwtException("이메일 인증 오류");
-            }
-        }
-
-        /*
-         전화번호 검증
-         */
-        if (!(PHONE_NUMBER == null || PHONE_NUMBER.isBlank())) {
-            try {
-                DataFormatUtils.checkPhoneNumberFormat(PHONE_NUMBER);    // 전화번호 형식 체크
-
-                Cookie verifiedToken = WebUtils.getCookie(request, "st_phone_auth_vf_token");
-
-                String phoneAuthToken = verifiedToken.getValue();
-                String PHONE_AUTH_JWT_KEY = PHONE_NUMBER + PHONE_AUTH_JWT_SECRET;
-
-                Jwts.parser().setSigningKey(PHONE_AUTH_JWT_KEY).parseClaimsJws(phoneAuthToken).getBody();
-
-                // st_phone_auth_vf_token 제거
-                ResponseCookie phoneAuthVerifiedToken = ResponseCookie.from("st_phone_auth_vf_token", null)
-                        .domain(CustomCookieInterface.COOKIE_DOMAIN)
-                        .sameSite("Strict")
-                        .path("/")
-                        .maxAge(0)
-                        .build();
-                response.addHeader(HttpHeaders.SET_COOKIE, phoneAuthVerifiedToken.toString());
-            } catch (ExpiredJwtException e) {     // 토큰 만료
-                throw new UserInfoAuthJwtException("전화번호 인증 토큰이 만료되었습니다.");
-            } catch (NullPointerException e) {   // Phone Auth Number 쿠키가 존재하지 않는다면
-                throw new UserInfoAuthJwtException("전화번호 인증을 먼저 진행해주세요.");
-            } catch (Exception e) {
-                throw new UserInfoAuthJwtException("전화번호 인증 오류");
-            }
+            // st_email_auth_vf_token 제거
+            ResponseCookie emailAuthVerifiedToken = ResponseCookie.from("st_email_auth_vf_token", null)
+                    .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                    .sameSite("Strict")
+                    .path("/")
+                    .maxAge(0)
+                    .build();
+            response.addHeader(HttpHeaders.SET_COOKIE, emailAuthVerifiedToken.toString());
+        } catch (ExpiredJwtException e) {     // 토큰 만료
+            throw new UserInfoAuthJwtException("이메일 인증 토큰이 만료되었습니다.");
+        } catch (NullPointerException e) {   // Email Auth Number 쿠키가 존재하지 않는다면
+            throw new UserInfoAuthJwtException("이메일 인증을 먼저 진행해주세요.");
+        } catch (Exception e) {
+            throw new UserInfoAuthJwtException("이메일 인증 오류");
         }
 
         String SALT = UUID.randomUUID().toString();
@@ -150,7 +113,6 @@ public class SignupBusinessService {
                 .password(ENC_PASSWORD)
                 .email(EMAIL)
                 .nickname(NICKNAME)
-                .phoneNumber(PHONE_NUMBER)
                 .salt(SALT)
                 .roles(UserUtils.ROLE_USER)
                 .allowedAccessCount(UserUtils.ALLOWED_ACCESS_COUNT_DEFAULT)

--- a/src/main/java/com/sellertool/auth_server/domain/signup/service/SignupBusinessService.java
+++ b/src/main/java/com/sellertool/auth_server/domain/signup/service/SignupBusinessService.java
@@ -78,7 +78,7 @@ public class SignupBusinessService {
         /*
         이메일 검증
          */
-        if (!(EMAIL == null || EMAIL.isBlank() || EMAIL.isEmpty())) {
+        if (!(EMAIL == null || EMAIL.isBlank())) {
             try {
                 DataFormatUtils.checkEmailFormat(EMAIL);    // 이메일 형식 체크
 
@@ -109,7 +109,7 @@ public class SignupBusinessService {
         /*
          전화번호 검증
          */
-        if (!(PHONE_NUMBER == null || PHONE_NUMBER.isBlank() || PHONE_NUMBER.isEmpty())) {
+        if (!(PHONE_NUMBER == null || PHONE_NUMBER.isBlank())) {
             try {
                 DataFormatUtils.checkPhoneNumberFormat(PHONE_NUMBER);    // 전화번호 형식 체크
 

--- a/src/main/java/com/sellertool/auth_server/domain/user/controller/UserApiV1.java
+++ b/src/main/java/com/sellertool/auth_server/domain/user/controller/UserApiV1.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -28,12 +27,12 @@ public class UserApiV1 {
     }
 
     @GetMapping("/info/own")
-    public ResponseEntity<?> getInfoOwn(){
+    public ResponseEntity<?> getInfoOwn(HttpServletResponse response){
         Message message = new Message();
 
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
-        message.setData(userBusinessService.getInfoOwn());
+        message.setData(userBusinessService.getInfoOwn(response));
 
         return new ResponseEntity<>(message, message.getStatus());
     }
@@ -67,50 +66,6 @@ public class UserApiV1 {
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
         userBusinessService.changePassword(password);
-
-        return new ResponseEntity<>(message, message.getStatus());
-    }
-
-    @GetMapping("/phone")
-    public ResponseEntity<?> getPhoneAuthNumber(@RequestParam Map<String, Object> params, HttpServletResponse response){
-        Message message = new Message();
-
-        message.setStatus(HttpStatus.OK);
-        message.setMessage("success");
-        userBusinessService.getPhoneAuthNumber(params, response);
-
-        return new ResponseEntity<>(message, message.getStatus());
-    }
-
-    @GetMapping("/phone/verify")
-    public ResponseEntity<?> verifyPhoneAuthNumber(HttpServletRequest request, HttpServletResponse response, @RequestParam Map<String, Object> params){
-        Message message = new Message();
-
-        message.setStatus(HttpStatus.OK);
-        message.setMessage("success");
-        userBusinessService.verifyPhoneAuthNumber(request, response, params);
-
-        return new ResponseEntity<>(message, message.getStatus());
-    }
-
-    @GetMapping("/email")
-    public ResponseEntity<?> getEmailAuthNumber(@RequestParam Map<String, Object> params, HttpServletResponse response) throws IOException {
-        Message message = new Message();
-
-        message.setStatus(HttpStatus.OK);
-        message.setMessage("success");
-        userBusinessService.getEmailAuthNumber(params, response);
-
-        return new ResponseEntity<>(message, message.getStatus());
-    }
-
-    @GetMapping("/email/verify")
-    public ResponseEntity<?> verifyEmailAuthNumber(HttpServletRequest request, HttpServletResponse response, @RequestParam Map<String, Object> params){
-        Message message = new Message();
-
-        message.setStatus(HttpStatus.OK);
-        message.setMessage("success");
-        userBusinessService.verifyEmailAuthNumber(request, response, params);
 
         return new ResponseEntity<>(message, message.getStatus());
     }

--- a/src/main/java/com/sellertool/auth_server/domain/user/dto/UserDto.java
+++ b/src/main/java/com/sellertool/auth_server/domain/user/dto/UserDto.java
@@ -24,13 +24,14 @@ public class UserDto {
     @NotBlank
     private String nickname;
 
+    @NotBlank
     private String roles;
 
     private String name;
 
+    @NotBlank
     private String email;
 
-    @NotBlank
     private String phoneNumber;
 
     public static UserDto toDto(UserEntity entity) {

--- a/src/main/java/com/sellertool/auth_server/domain/user/dto/UserDto.java
+++ b/src/main/java/com/sellertool/auth_server/domain/user/dto/UserDto.java
@@ -14,7 +14,8 @@ import java.util.UUID;
 @NoArgsConstructor
 @Builder
 public class UserDto {
-    @NotBlank
+
+    @NotNull
     private UUID id;
 
     @NotBlank
@@ -23,12 +24,10 @@ public class UserDto {
     @NotBlank
     private String nickname;
 
-    @NotBlank
     private String roles;
 
     private String name;
 
-    @NotBlank
     private String email;
 
     @NotBlank

--- a/src/main/java/com/sellertool/auth_server/domain/user/service/UserBusinessService.java
+++ b/src/main/java/com/sellertool/auth_server/domain/user/service/UserBusinessService.java
@@ -143,86 +143,85 @@ public class UserBusinessService {
         UserEntity userEntity = userService.searchUserByUserId(USER_ID);
 
         /*
-        이메일 검증 (선택값)
-         */
-        if (!(userDto.getEmail() == null || userDto.getEmail().isBlank())) {
-            try {
-                Cookie authToken = WebUtils.getCookie(request, "st_email_auth_token");
-                Cookie verifiedToken = WebUtils.getCookie(request, "st_email_auth_vf_token");
-                String USER_EMAIL = userEntity.getEmail() == null ? "" : userEntity.getEmail();
-
-                // 인증번호 요청 토큰이 존재하지 않고, 이메일 입력값만 변경된 경우 제한
-                if (authToken == null) {
-                    if(verifiedToken != null || !USER_EMAIL.equals(userDto.getEmail())) {
-                        String email = userDto.getEmail();
-                        DataFormatUtils.checkEmailFormat(email);    // 이메일 형식 체크
-
-                        String emailAuthToken = verifiedToken.getValue();
-                        String EMAIL_AUTH_JWT_KEY = email + EMAIL_AUTH_JWT_SECRET;
-
-                        Jwts.parser().setSigningKey(EMAIL_AUTH_JWT_KEY).parseClaimsJws(emailAuthToken).getBody();
-
-                        // st_email_auth_vf_token 제거
-                        ResponseCookie emailAuthVerifiedToken = ResponseCookie.from("st_email_auth_vf_token", null)
-                                .domain(CustomCookieInterface.COOKIE_DOMAIN)
-                                .sameSite("Strict")
-                                .path("/")
-                                .maxAge(0)
-                                .build();
-                        response.addHeader(HttpHeaders.SET_COOKIE, emailAuthVerifiedToken.toString());
-                    }
-                } else {
-                    throw new UserInfoAuthJwtException("이메일 인증이 완료되지 않았습니다.");
-                }
-            } catch (ExpiredJwtException e) {     // 토큰 만료
-                throw new UserInfoAuthJwtException("이메일 인증 토큰이 만료되었습니다.");
-            } catch (SignatureException e) {
-                throw new UserInfoAuthJwtException("이메일 인증이 완료되지 않았습니다.");
-            } catch (NullPointerException e) {   // Phone Auth Number 쿠키가 존재하지 않는다면
-                throw new UserInfoAuthJwtException("이메일 인증이 완료되지 않았습니다.");
-            }
-        }
-
-
-        /*
-         전화번호 검증
+        이메일 검증
          */
         try {
-            Cookie authToken = WebUtils.getCookie(request, "st_phone_auth_token");
-            Cookie verifiedToken = WebUtils.getCookie(request, "st_phone_auth_vf_token");
-            String USER_PHONE_NUMBER = userEntity.getPhoneNumber() == null ? "" : userEntity.getPhoneNumber();
+            Cookie authToken = WebUtils.getCookie(request, "st_email_auth_token");
+            Cookie verifiedToken = WebUtils.getCookie(request, "st_email_auth_vf_token");
+            String USER_EMAIL = userEntity.getEmail() == null ? "" : userEntity.getEmail();
 
-            if (authToken == null){
-                // 전화번호 입력값만 변경된 경우 제한
-                if(verifiedToken != null || !USER_PHONE_NUMBER.equals(userDto.getPhoneNumber())) {
-                    String phoneNumber = userDto.getPhoneNumber();
-                    DataFormatUtils.checkPhoneNumberFormat(phoneNumber);    // 전화번호 형식 체크
+            // 인증번호 요청 토큰이 존재하지 않고, 이메일 입력값만 변경된 경우 제한
+            if (authToken == null) {
+                if (verifiedToken != null || !USER_EMAIL.equals(userDto.getEmail())) {
+                    String email = userDto.getEmail();
+                    DataFormatUtils.checkEmailFormat(email);    // 이메일 형식 체크
 
-                    String phoneAuthToken = verifiedToken.getValue();
-                    String PHONE_AUTH_JWT_KEY = phoneNumber + PHONE_AUTH_JWT_SECRET;
+                    String emailAuthToken = verifiedToken.getValue();
+                    String EMAIL_AUTH_JWT_KEY = email + EMAIL_AUTH_JWT_SECRET;
 
-                    Jwts.parser().setSigningKey(PHONE_AUTH_JWT_KEY).parseClaimsJws(phoneAuthToken).getBody();
+                    Jwts.parser().setSigningKey(EMAIL_AUTH_JWT_KEY).parseClaimsJws(emailAuthToken).getBody();
 
-                    // st_phone_auth_vf_token 제거
-                    ResponseCookie phoneAuthVerifiedToken = ResponseCookie.from("st_phone_auth_vf_token", null)
+                    // st_email_auth_vf_token 제거
+                    ResponseCookie emailAuthVerifiedToken = ResponseCookie.from("st_email_auth_vf_token", null)
                             .domain(CustomCookieInterface.COOKIE_DOMAIN)
                             .sameSite("Strict")
                             .path("/")
                             .maxAge(0)
                             .build();
-                    response.addHeader(HttpHeaders.SET_COOKIE, phoneAuthVerifiedToken.toString());
+                    response.addHeader(HttpHeaders.SET_COOKIE, emailAuthVerifiedToken.toString());
                 }
-            }else {
-                throw new UserInfoAuthJwtException("전화번호 인증이 완료되지 않았습니다.");
+            } else {
+                throw new UserInfoAuthJwtException("이메일 인증이 완료되지 않았습니다.");
             }
         } catch (ExpiredJwtException e) {     // 토큰 만료
-            throw new UserInfoAuthJwtException("전화번호 인증 토큰이 만료되었습니다.");
+            throw new UserInfoAuthJwtException("이메일 인증 토큰이 만료되었습니다.");
         } catch (SignatureException e) {
-            throw new UserInfoAuthJwtException("전화번호 인증이 올바르지 않습니다.");
+            throw new UserInfoAuthJwtException("이메일 인증이 완료되지 않았습니다.");
         } catch (NullPointerException e) {   // Phone Auth Number 쿠키가 존재하지 않는다면
-            throw new UserInfoAuthJwtException("전화번호 인증이 완료되지 않았습니다.");
-        } catch (Exception e) {
-            throw new UserInfoAuthJwtException("전화번호 인증이 완료되지 않았습니다.");
+            throw new UserInfoAuthJwtException("이메일 인증이 완료되지 않았습니다.");
+        }
+
+        /*
+         전화번호 검증 (선택 값)
+         */
+        if (!(userDto.getPhoneNumber() == null || userDto.getPhoneNumber().isBlank())) {
+            try {
+                Cookie authToken = WebUtils.getCookie(request, "st_phone_auth_token");
+                Cookie verifiedToken = WebUtils.getCookie(request, "st_phone_auth_vf_token");
+                String USER_PHONE_NUMBER = userEntity.getPhoneNumber() == null ? "" : userEntity.getPhoneNumber();
+
+                if (authToken == null) {
+                    // 전화번호 입력값만 변경된 경우 제한
+                    if (verifiedToken != null || !USER_PHONE_NUMBER.equals(userDto.getPhoneNumber())) {
+                        String phoneNumber = userDto.getPhoneNumber();
+                        DataFormatUtils.checkPhoneNumberFormat(phoneNumber);    // 전화번호 형식 체크
+
+                        String phoneAuthToken = verifiedToken.getValue();
+                        String PHONE_AUTH_JWT_KEY = phoneNumber + PHONE_AUTH_JWT_SECRET;
+
+                        Jwts.parser().setSigningKey(PHONE_AUTH_JWT_KEY).parseClaimsJws(phoneAuthToken).getBody();
+
+                        // st_phone_auth_vf_token 제거
+                        ResponseCookie phoneAuthVerifiedToken = ResponseCookie.from("st_phone_auth_vf_token", null)
+                                .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                                .sameSite("Strict")
+                                .path("/")
+                                .maxAge(0)
+                                .build();
+                        response.addHeader(HttpHeaders.SET_COOKIE, phoneAuthVerifiedToken.toString());
+                    }
+                } else {
+                    throw new UserInfoAuthJwtException("전화번호 인증이 완료되지 않았습니다.");
+                }
+            } catch (ExpiredJwtException e) {     // 토큰 만료
+                throw new UserInfoAuthJwtException("전화번호 인증 토큰이 만료되었습니다.");
+            } catch (SignatureException e) {
+                throw new UserInfoAuthJwtException("전화번호 인증이 올바르지 않습니다.");
+            } catch (NullPointerException e) {   // Phone Auth Number 쿠키가 존재하지 않는다면
+                throw new UserInfoAuthJwtException("전화번호 인증이 완료되지 않았습니다.");
+            } catch (Exception e) {
+                throw new UserInfoAuthJwtException("전화번호 인증이 완료되지 않았습니다.");
+            }
         }
 
         /*

--- a/src/main/java/com/sellertool/auth_server/domain/user/service/UserBusinessService.java
+++ b/src/main/java/com/sellertool/auth_server/domain/user/service/UserBusinessService.java
@@ -1,38 +1,21 @@
 package com.sellertool.auth_server.domain.user.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sellertool.auth_server.domain.email.MailRequest;
-import com.sellertool.auth_server.domain.email.ReceipientForRequest;
 import com.sellertool.auth_server.domain.exception.dto.*;
 import com.sellertool.auth_server.domain.user.dto.UserDto;
 import com.sellertool.auth_server.domain.user.entity.UserEntity;
 import com.sellertool.auth_server.domain.user.vo.UserVo;
-import com.sellertool.auth_server.utils.UserAuthInfoUtils;
 import com.sellertool.auth_server.utils.CustomCookieInterface;
 import com.sellertool.auth_server.utils.DataFormatUtils;
-import com.sellertool.auth_server.utils.UserInfoAuthTokenUtils;
-import com.twilio.Twilio;
 
-import com.twilio.rest.api.v2010.account.Message;
-import com.twilio.type.PhoneNumber;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.WebUtils;
 
-import java.io.*;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -44,37 +27,20 @@ import javax.servlet.http.HttpServletResponse;
 @RequiredArgsConstructor
 public class UserBusinessService {
 
-    @Value("${twilio.account.sid}")
-    private String ACCOUNT_SID;
-
-    @Value("${twilio.auth.token}")
-    private String AUTH_TOKEN;
-
-    @Value("${twilio.from.number}")
-    private String FROM_NUMBER;
-
-    @Value("${email.admin.id}")
-    private String EMAIL_ID;
-
-    @Value("${naver.cloud.platform.request.url}")
-    private String MAIL_REQUEST_URL;
-
-    @Value("${naver.cloud.platform.request.mail.api}")
-    private String MAIL_REQUEST_API;
-
     @Value("${phone.auth.token.secret}")
     private String PHONE_AUTH_JWT_SECRET;
 
     @Value("${email.auth.token.secret}")
     private String EMAIL_AUTH_JWT_SECRET;
 
-    private String KOREA_COUNTRY_NUMBER = "+82";
-
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional(readOnly = true)
-    public Object getInfoOwn() {
+    public Object getInfoOwn(HttpServletResponse response) {
+        // 이메일, 전화번호 인증 토큰 제거
+        this.removeUserInfoAuthCookie(response);
+
         if (!userService.isLogin()) {
             throw new InvalidUserAuthException("로그인이 필요한 서비스 입니다.");
         }
@@ -82,6 +48,49 @@ public class UserBusinessService {
         UUID USER_ID = userService.getUserId();
         UserVo userVo = UserVo.toVo(userService.searchUserByUserId(USER_ID));
         return userVo;
+    }
+
+    /*
+    이메일 인증 요청 토큰 제거
+    이메일 인증 성공 토큰 제거
+    전화번호 인증 요청 토큰 제거
+    전화번호 인증 성공 토큰 제거
+     */
+    public void removeUserInfoAuthCookie(HttpServletResponse response) {
+        ResponseCookie rmEmailAuthToken = ResponseCookie.from("st_email_auth_token", null)
+                .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        ResponseCookie rmEmailAuthVerifiedToken = ResponseCookie.from("st_email_auth_vf_token", null)
+                .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        // st_phone_auth_vf_token 제거
+        ResponseCookie rmPhoneAuthToken = ResponseCookie.from("st_phone_auth_token", null)
+                .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        // st_phone_auth_vf_token 제거
+        ResponseCookie rmPhoneAuthVerifiedToken = ResponseCookie.from("st_phone_auth_vf_token", null)
+                .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, rmEmailAuthToken.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, rmEmailAuthVerifiedToken.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, rmPhoneAuthToken.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, rmPhoneAuthVerifiedToken.toString());
     }
 
     @Transactional(readOnly = true)
@@ -134,67 +143,86 @@ public class UserBusinessService {
         UserEntity userEntity = userService.searchUserByUserId(USER_ID);
 
         /*
-        이메일 검증
+        이메일 검증 (선택값)
          */
-        if (!userEntity.getEmail().equals(userDto.getEmail())) {
+        if (!(userDto.getEmail() == null || userDto.getEmail().isBlank())) {
             try {
-                String email = userDto.getEmail();
-                DataFormatUtils.checkEmailFormat(email);    // 이메일 형식 체크
-
+                Cookie authToken = WebUtils.getCookie(request, "st_email_auth_token");
                 Cookie verifiedToken = WebUtils.getCookie(request, "st_email_auth_vf_token");
+                String USER_EMAIL = userEntity.getEmail() == null ? "" : userEntity.getEmail();
 
-                String emailAuthToken = verifiedToken.getValue();
-                String EMAIL_AUTH_JWT_KEY = email + EMAIL_AUTH_JWT_SECRET;
+                // 인증번호 요청 토큰이 존재하지 않고, 이메일 입력값만 변경된 경우 제한
+                if (authToken == null) {
+                    if(verifiedToken != null || !USER_EMAIL.equals(userDto.getEmail())) {
+                        String email = userDto.getEmail();
+                        DataFormatUtils.checkEmailFormat(email);    // 이메일 형식 체크
 
-                Jwts.parser().setSigningKey(EMAIL_AUTH_JWT_KEY).parseClaimsJws(emailAuthToken).getBody();
+                        String emailAuthToken = verifiedToken.getValue();
+                        String EMAIL_AUTH_JWT_KEY = email + EMAIL_AUTH_JWT_SECRET;
 
-                // st_email_auth_vf_token 제거
-                ResponseCookie emailAuthVerifiedToken = ResponseCookie.from("st_email_auth_vf_token", null)
-                        .domain(CustomCookieInterface.COOKIE_DOMAIN)
-                        .sameSite("Strict")
-                        .path("/")
-                        .maxAge(0)
-                        .build();
-                response.addHeader(HttpHeaders.SET_COOKIE, emailAuthVerifiedToken.toString());
+                        Jwts.parser().setSigningKey(EMAIL_AUTH_JWT_KEY).parseClaimsJws(emailAuthToken).getBody();
+
+                        // st_email_auth_vf_token 제거
+                        ResponseCookie emailAuthVerifiedToken = ResponseCookie.from("st_email_auth_vf_token", null)
+                                .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                                .sameSite("Strict")
+                                .path("/")
+                                .maxAge(0)
+                                .build();
+                        response.addHeader(HttpHeaders.SET_COOKIE, emailAuthVerifiedToken.toString());
+                    }
+                } else {
+                    throw new UserInfoAuthJwtException("이메일 인증이 완료되지 않았습니다.");
+                }
             } catch (ExpiredJwtException e) {     // 토큰 만료
                 throw new UserInfoAuthJwtException("이메일 인증 토큰이 만료되었습니다.");
+            } catch (SignatureException e) {
+                throw new UserInfoAuthJwtException("이메일 인증이 완료되지 않았습니다.");
             } catch (NullPointerException e) {   // Phone Auth Number 쿠키가 존재하지 않는다면
-                throw new UserInfoAuthJwtException("이메일 인증을 먼저 진행해주세요.");
-            } catch (Exception e) {
-                throw new UserInfoAuthJwtException("이메일 인증 오류");
+                throw new UserInfoAuthJwtException("이메일 인증이 완료되지 않았습니다.");
             }
         }
+
 
         /*
          전화번호 검증
          */
-        if (!userEntity.getPhoneNumber().equals(userDto.getPhoneNumber())) {
-            try {
-                String phoneNumber = userDto.getPhoneNumber();
-                DataFormatUtils.checkPhoneNumberFormat(phoneNumber);    // 전화번호 형식 체크
+        try {
+            Cookie authToken = WebUtils.getCookie(request, "st_phone_auth_token");
+            Cookie verifiedToken = WebUtils.getCookie(request, "st_phone_auth_vf_token");
+            String USER_PHONE_NUMBER = userEntity.getPhoneNumber() == null ? "" : userEntity.getPhoneNumber();
 
-                Cookie verifiedToken = WebUtils.getCookie(request, "st_phone_auth_vf_token");
+            if (authToken == null){
+                // 전화번호 입력값만 변경된 경우 제한
+                if(verifiedToken != null || !USER_PHONE_NUMBER.equals(userDto.getPhoneNumber())) {
+                    String phoneNumber = userDto.getPhoneNumber();
+                    DataFormatUtils.checkPhoneNumberFormat(phoneNumber);    // 전화번호 형식 체크
 
-                String phoneAuthToken = verifiedToken.getValue();
-                String PHONE_AUTH_JWT_KEY = phoneNumber + PHONE_AUTH_JWT_SECRET;
+                    String phoneAuthToken = verifiedToken.getValue();
+                    String PHONE_AUTH_JWT_KEY = phoneNumber + PHONE_AUTH_JWT_SECRET;
 
-                Jwts.parser().setSigningKey(PHONE_AUTH_JWT_KEY).parseClaimsJws(phoneAuthToken).getBody();
+                    Jwts.parser().setSigningKey(PHONE_AUTH_JWT_KEY).parseClaimsJws(phoneAuthToken).getBody();
 
-                // st_phone_auth_vf_token 제거
-                ResponseCookie phoneAuthVerifiedToken = ResponseCookie.from("st_phone_auth_vf_token", null)
-                        .domain(CustomCookieInterface.COOKIE_DOMAIN)
-                        .sameSite("Strict")
-                        .path("/")
-                        .maxAge(0)
-                        .build();
-                response.addHeader(HttpHeaders.SET_COOKIE, phoneAuthVerifiedToken.toString());
-            } catch (ExpiredJwtException e) {     // 토큰 만료
-                throw new UserInfoAuthJwtException("전화번호 인증 토큰이 만료되었습니다.");
-            } catch (NullPointerException e) {   // Phone Auth Number 쿠키가 존재하지 않는다면
-                throw new UserInfoAuthJwtException("전화번호 인증을 먼저 진행해주세요.");
-            } catch (Exception e) {
-                throw new UserInfoAuthJwtException("전화번호 인증 오류");
+                    // st_phone_auth_vf_token 제거
+                    ResponseCookie phoneAuthVerifiedToken = ResponseCookie.from("st_phone_auth_vf_token", null)
+                            .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                            .sameSite("Strict")
+                            .path("/")
+                            .maxAge(0)
+                            .build();
+                    response.addHeader(HttpHeaders.SET_COOKIE, phoneAuthVerifiedToken.toString());
+                }
+            }else {
+                throw new UserInfoAuthJwtException("전화번호 인증이 완료되지 않았습니다.");
             }
+        } catch (ExpiredJwtException e) {     // 토큰 만료
+            throw new UserInfoAuthJwtException("전화번호 인증 토큰이 만료되었습니다.");
+        } catch (SignatureException e) {
+            throw new UserInfoAuthJwtException("전화번호 인증이 올바르지 않습니다.");
+        } catch (NullPointerException e) {   // Phone Auth Number 쿠키가 존재하지 않는다면
+            throw new UserInfoAuthJwtException("전화번호 인증이 완료되지 않았습니다.");
+        } catch (Exception e) {
+            throw new UserInfoAuthJwtException("전화번호 인증이 완료되지 않았습니다.");
         }
 
         /*
@@ -267,235 +295,5 @@ public class UserBusinessService {
          */
         userEntity.setPassword(encNewPassword);
         userEntity.setSalt(newSalt);
-    }
-
-    public void getPhoneAuthNumber(Map<String, Object> params, HttpServletResponse response) {
-        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
-
-        String phoneNumber = params.get("phoneNumber").toString();
-        DataFormatUtils.checkPhoneNumberFormat(phoneNumber);    // 전화번호 형식 체크
-
-        String authNum = UserAuthInfoUtils.generateAuthNumber();
-        String sendPhoneNumber = KOREA_COUNTRY_NUMBER + phoneNumber;
-        String sendMessage = "[셀러툴] 본인확인 인증번호[" + authNum + "]입니다. \"타인 노출 금지\"";
-
-        // SMS 전송
-        Message.creator(new PhoneNumber(sendPhoneNumber), new PhoneNumber(FROM_NUMBER), sendMessage).create();
-
-        String authNumToken = UserInfoAuthTokenUtils.getPhoneAuthNumberJwtToken(authNum, phoneNumber);
-
-        ResponseCookie phoneAuthToken = ResponseCookie.from("st_phone_auth_token", authNumToken)
-                .secure(CustomCookieInterface.SECURE)
-                .domain(CustomCookieInterface.COOKIE_DOMAIN)
-                .sameSite("Strict")
-                .path("/")
-                .maxAge(CustomCookieInterface.PHONE_AUTH_COOKIE_EXPIRATION)
-                .build();
-
-        response.addHeader(HttpHeaders.SET_COOKIE, phoneAuthToken.toString());
-
-        ResponseCookie phoneAuthVerifiedToken = ResponseCookie.from("st_phone_auth_vf_token", null)
-                .domain(CustomCookieInterface.COOKIE_DOMAIN)
-                .sameSite("Strict")
-                .path("/")
-                .maxAge(0)
-                .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, phoneAuthVerifiedToken.toString());
-    }
-
-    public void verifyPhoneAuthNumber(HttpServletRequest request, HttpServletResponse response, Map<String, Object> params) {
-        try {
-            String phoneNumber = params.get("phoneNumber").toString();
-            String phoneAuthNumber = params.get("phoneAuthNumber").toString();
-            DataFormatUtils.checkPhoneNumberFormat(phoneNumber);    // 전화번호 형식 체크
-
-            Cookie authCookie = WebUtils.getCookie(request, "st_phone_auth_token");
-
-            String phoneAuthJwtToken = authCookie.getValue();
-            String PHONE_AUTH_JWT_KEY = phoneAuthNumber + PHONE_AUTH_JWT_SECRET;
-
-            // 인증번호 검증
-            Claims claims = Jwts.parser().setSigningKey(PHONE_AUTH_JWT_KEY).parseClaimsJws(phoneAuthJwtToken).getBody();
-
-            if(!claims.get("phoneNumber").equals(phoneNumber)) {
-                throw new UserInfoAuthJwtException("인증 요청이 올바르지 않습니다.");
-            }
-
-            // 인증되었다면 새로운 JWT 쿠키 생성
-            String authToken = UserInfoAuthTokenUtils.getPhoneAuthVerifiedJwtToken(phoneNumber);
-
-            ResponseCookie phoneAuthVerifiedToken = ResponseCookie.from("st_phone_auth_vf_token", authToken)
-                    .secure(CustomCookieInterface.SECURE)
-                    .domain(CustomCookieInterface.COOKIE_DOMAIN)
-                    .sameSite("Strict")
-                    .path("/")
-                    .maxAge(CustomCookieInterface.PHONE_AUTH_VF_COOKIE_EXPIRATION)
-                    .build();
-
-            response.addHeader(HttpHeaders.SET_COOKIE, phoneAuthVerifiedToken.toString());
-
-            // st_phone_auth_token 제거
-            ResponseCookie phoneAuthToken = ResponseCookie.from("st_phone_auth_token", null)
-                    .domain(CustomCookieInterface.COOKIE_DOMAIN)
-                    .sameSite("Strict")
-                    .path("/")
-                    .maxAge(0)
-                    .build();
-            response.addHeader(HttpHeaders.SET_COOKIE, phoneAuthToken.toString());
-        } catch (ExpiredJwtException e) {     // 토큰 만료
-            throw new UserInfoAuthJwtException("인증 요청시간이 만료되었습니다.");
-        } catch (NullPointerException e) {   // Phone Auth Number 쿠키가 존재하지 않는다면
-            throw new UserInfoAuthJwtException("인증 요청이 올바르지 않습니다.");
-        } catch (IllegalArgumentException e) {
-            throw new UserInfoAuthJwtException("인증 요청이 올바르지 않습니다.");
-        } catch (UnsupportedJwtException e) {
-            throw new UserInfoAuthJwtException("인증 요청이 올바르지 않습니다.");
-        } catch (MalformedJwtException e) {
-            throw new UserInfoAuthJwtException("인증 요청이 올바르지 않습니다.");
-        } catch (SignatureException e) {
-            throw new UserInfoAuthJwtException("인증 요청이 올바르지 않습니다.");
-        }
-    }
-
-    private String readFromInputStream(InputStream inputStream)
-            throws IOException {
-        StringBuilder resultStringBuilder = new StringBuilder();
-        try (BufferedReader br
-                     = new BufferedReader(new InputStreamReader(inputStream))) {
-            String line;
-            while ((line = br.readLine()) != null) {
-                resultStringBuilder.append(line).append("\n");
-            }
-        }
-        return resultStringBuilder.toString();
-    }
-
-    public void getEmailAuthNumber(Map<String, Object> params, HttpServletResponse response) throws IOException {
-        Long time = System.currentTimeMillis();
-        String sendEmail = params.get("email").toString();
-        DataFormatUtils.checkEmailFormat(sendEmail);    // 이메일 형식 체크
-
-        String authNum = UserAuthInfoUtils.generateAuthNumber();
-        String sendMessage = "";
-//        String sendMessage = "[셀러툴] 본인확인 인증번호[" + authNum + "]입니다. \"타인 노출 금지\"";
-
-        FileInputStream emailTemplate = new FileInputStream("src/main/resources/static/emailAuthTemplate");
-        sendMessage = IOUtils.toString(emailTemplate, "UTF-8");
-        sendMessage = sendMessage.replaceFirst("------", authNum);
-
-        List<ReceipientForRequest> receipients = new ArrayList<>();
-        ReceipientForRequest receipient = ReceipientForRequest.builder()
-                .address(sendEmail)
-                .type("R")
-                .build();
-        receipients.add(receipient);
-
-        MailRequest mailRequest = MailRequest.builder()
-                .senderAddress(EMAIL_ID)
-                .senderName("Sellertool")
-                .title("[셀러툴] 이메일 인증")
-                .body(sendMessage)
-                .recipients(receipients)
-                .build();
-
-        // 메일 전송
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            String jsonBody = objectMapper.writeValueAsString(mailRequest);
-            HttpHeaders headers = UserAuthInfoUtils.setApiRequestHeader(time);
-
-            HttpEntity<String> body = new HttpEntity<>(jsonBody, headers);
-            RestTemplate restTemplate = new RestTemplate();
-            restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
-            restTemplate.postForObject(new URI(MAIL_REQUEST_URL + MAIL_REQUEST_API), body, HashMap.class);
-        } catch(URISyntaxException e) {
-            throw new EmailAuthException("이메일 전송이 불가능합니다.");
-        } catch(JsonProcessingException e) {
-            throw new EmailAuthException("이메일 전송이 불가능합니다.");
-        } catch(InvalidKeyException e) {
-            throw new EmailAuthException("이메일 전송이 불가능합니다.");
-        } catch(NoSuchAlgorithmException e) {
-            throw new EmailAuthException("이메일 전송이 불가능합니다.");
-        } catch(UnsupportedEncodingException e) {
-            throw new EmailAuthException("이메일 전송이 불가능합니다.");
-        } catch(Exception e) {
-            e.printStackTrace();
-            throw new EmailAuthException("이메일 전송이 불가능합니다.");
-        }
-
-        String authNumToken = UserInfoAuthTokenUtils.getEmailAuthNumberJwtToken(authNum, sendEmail);
-
-        ResponseCookie emailAuthToken = ResponseCookie.from("st_email_auth_token", authNumToken)
-                .secure(CustomCookieInterface.SECURE)
-                .domain(CustomCookieInterface.COOKIE_DOMAIN)
-                .sameSite("Strict")
-                .path("/")
-                .maxAge(CustomCookieInterface.EMAIL_AUTH_COOKIE_EXPIRATION)
-                .build();
-
-        response.addHeader(HttpHeaders.SET_COOKIE, emailAuthToken.toString());
-
-        // st_email_auth_vf_token 제거
-        ResponseCookie emailAuthVerifiedToken = ResponseCookie.from("st_email_auth_vf_token", null)
-                .domain(CustomCookieInterface.COOKIE_DOMAIN)
-                .sameSite("Strict")
-                .path("/")
-                .maxAge(0)
-                .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, emailAuthVerifiedToken.toString());
-    }
-
-    public void verifyEmailAuthNumber(HttpServletRequest request, HttpServletResponse response, Map<String, Object> params) {
-        try {
-            String email = params.get("email").toString();
-            String emailAuthNumber = params.get("emailAuthNumber").toString();
-            DataFormatUtils.checkEmailFormat(email);    // 이메일 형식 체크
-
-            Cookie authCookie = WebUtils.getCookie(request, "st_email_auth_token");
-
-            String emailAuthJwtToken = authCookie.getValue();
-            String EMAIL_AUTH_JWT_KEY = emailAuthNumber + EMAIL_AUTH_JWT_SECRET;
-
-            // 인증번호 검증
-            Claims claims = Jwts.parser().setSigningKey(EMAIL_AUTH_JWT_KEY).parseClaimsJws(emailAuthJwtToken).getBody();
-
-            if(!claims.get("email").equals(email)) {
-                throw new UserInfoAuthJwtException("인증 요청이 올바르지 않습니다.");
-            }
-
-            // 인증되었다면 새로운 JWT 쿠키 생성
-            String authToken = UserInfoAuthTokenUtils.getEmailAuthVerifiedJwtToken(email);
-
-            ResponseCookie emailAuthVerifiedToken = ResponseCookie.from("st_email_auth_vf_token", authToken)
-                    .secure(CustomCookieInterface.SECURE)
-                    .domain(CustomCookieInterface.COOKIE_DOMAIN)
-                    .sameSite("Strict")
-                    .path("/")
-                    .maxAge(CustomCookieInterface.EMAIL_AUTH_VF_COOKIE_EXPIRATION)
-                    .build();
-
-            response.addHeader(HttpHeaders.SET_COOKIE, emailAuthVerifiedToken.toString());
-
-            // st_email_auth_token 제거
-            ResponseCookie emailAuthToken = ResponseCookie.from("st_email_auth_token", null)
-                    .domain(CustomCookieInterface.COOKIE_DOMAIN)
-                    .sameSite("Strict")
-                    .path("/")
-                    .maxAge(0)
-                    .build();
-            response.addHeader(HttpHeaders.SET_COOKIE, emailAuthToken.toString());
-        } catch (ExpiredJwtException e) {     // 토큰 만료
-            throw new UserInfoAuthJwtException("인증 요청시간이 만료되었습니다.");
-        } catch (NullPointerException e) {   // Email Auth Number 쿠키가 존재하지 않는다면
-            throw new UserInfoAuthJwtException("인증 요청이 올바르지 않습니다.");
-        } catch (IllegalArgumentException e) {
-            throw new UserInfoAuthJwtException("인증 요청이 올바르지 않습니다.");
-        } catch (UnsupportedJwtException e) {
-            throw new UserInfoAuthJwtException("인증 요청이 올바르지 않습니다.");
-        } catch (MalformedJwtException e) {
-            throw new UserInfoAuthJwtException("인증 요청이 올바르지 않습니다.");
-        } catch (SignatureException e) {
-            throw new UserInfoAuthJwtException("인증 요청이 올바르지 않습니다.");
-        }
     }
 }

--- a/src/main/java/com/sellertool/auth_server/domain/user_info_auth/controller/UserInfoAuthApiV1.java
+++ b/src/main/java/com/sellertool/auth_server/domain/user_info_auth/controller/UserInfoAuthApiV1.java
@@ -1,0 +1,67 @@
+package com.sellertool.auth_server.domain.user_info_auth.controller;
+
+import com.sellertool.auth_server.domain.message.dto.Message;
+import com.sellertool.auth_server.domain.user_info_auth.service.UserInfoAuthBusinessService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth/v1/user-info-auth")
+@RequiredArgsConstructor
+public class UserInfoAuthApiV1 {
+    private final UserInfoAuthBusinessService userInfoAuthBusinessService;
+
+    @GetMapping("/phone")
+    public ResponseEntity<?> getPhoneAuthNumber(@RequestParam Map<String, Object> params, HttpServletResponse response){
+        Message message = new Message();
+
+        message.setStatus(HttpStatus.OK);
+        message.setMessage("success");
+        userInfoAuthBusinessService.getPhoneAuthNumber(params, response);
+
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
+    @GetMapping("/phone/verify")
+    public ResponseEntity<?> verifyPhoneAuthNumber(HttpServletRequest request, HttpServletResponse response, @RequestParam Map<String, Object> params){
+        Message message = new Message();
+
+        message.setStatus(HttpStatus.OK);
+        message.setMessage("success");
+        userInfoAuthBusinessService.verifyPhoneAuthNumber(request, response, params);
+
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
+    @GetMapping("/email")
+    public ResponseEntity<?> getEmailAuthNumber(@RequestParam Map<String, Object> params, HttpServletResponse response) throws IOException {
+        Message message = new Message();
+
+        message.setStatus(HttpStatus.OK);
+        message.setMessage("success");
+        userInfoAuthBusinessService.getEmailAuthNumber(params, response);
+
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
+    @GetMapping("/email/verify")
+    public ResponseEntity<?> verifyEmailAuthNumber(HttpServletRequest request, HttpServletResponse response, @RequestParam Map<String, Object> params){
+        Message message = new Message();
+
+        message.setStatus(HttpStatus.OK);
+        message.setMessage("success");
+        userInfoAuthBusinessService.verifyEmailAuthNumber(request, response, params);
+
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+}

--- a/src/main/java/com/sellertool/auth_server/domain/user_info_auth/dto/email/MailRequest.java
+++ b/src/main/java/com/sellertool/auth_server/domain/user_info_auth/dto/email/MailRequest.java
@@ -1,4 +1,4 @@
-package com.sellertool.auth_server.domain.email;
+package com.sellertool.auth_server.domain.user_info_auth.dto.email;
 
 import lombok.*;
 

--- a/src/main/java/com/sellertool/auth_server/domain/user_info_auth/dto/email/ReceipientForRequest.java
+++ b/src/main/java/com/sellertool/auth_server/domain/user_info_auth/dto/email/ReceipientForRequest.java
@@ -1,4 +1,4 @@
-package com.sellertool.auth_server.domain.email;
+package com.sellertool.auth_server.domain.user_info_auth.dto.email;
 
 import lombok.*;
 import org.springframework.boot.context.properties.bind.DefaultValue;

--- a/src/main/java/com/sellertool/auth_server/domain/user_info_auth/service/UserInfoAuthBusinessService.java
+++ b/src/main/java/com/sellertool/auth_server/domain/user_info_auth/service/UserInfoAuthBusinessService.java
@@ -1,0 +1,285 @@
+package com.sellertool.auth_server.domain.user_info_auth.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sellertool.auth_server.domain.exception.dto.EmailAuthException;
+import com.sellertool.auth_server.domain.exception.dto.UserInfoAuthJwtException;
+import com.sellertool.auth_server.domain.user_info_auth.dto.email.MailRequest;
+import com.sellertool.auth_server.domain.user_info_auth.dto.email.ReceipientForRequest;
+import com.sellertool.auth_server.utils.CustomCookieInterface;
+import com.sellertool.auth_server.utils.DataFormatUtils;
+import com.sellertool.auth_server.utils.UserAuthInfoUtils;
+import com.sellertool.auth_server.utils.UserInfoAuthTokenUtils;
+import com.twilio.Twilio;
+import com.twilio.rest.api.v2010.account.Message;
+import com.twilio.type.PhoneNumber;
+import io.jsonwebtoken.*;
+import org.apache.commons.io.IOUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.WebUtils;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class UserInfoAuthBusinessService {
+
+    @Value("${twilio.account.sid}")
+    private String ACCOUNT_SID;
+
+    @Value("${twilio.auth.token}")
+    private String AUTH_TOKEN;
+
+    @Value("${twilio.from.number}")
+    private String FROM_NUMBER;
+
+    @Value("${email.admin.id}")
+    private String EMAIL_ID;
+
+    @Value("${naver.cloud.platform.request.url}")
+    private String MAIL_REQUEST_URL;
+
+    @Value("${naver.cloud.platform.request.mail.api}")
+    private String MAIL_REQUEST_API;
+
+    @Value("${phone.auth.token.secret}")
+    private String PHONE_AUTH_JWT_SECRET;
+
+    @Value("${email.auth.token.secret}")
+    private String EMAIL_AUTH_JWT_SECRET;
+
+    private String KOREA_COUNTRY_NUMBER = "+82";
+
+    public void getPhoneAuthNumber(Map<String, Object> params, HttpServletResponse response) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+
+        String phoneNumber = params.get("phoneNumber").toString();
+        DataFormatUtils.checkPhoneNumberFormat(phoneNumber);    // 전화번호 형식 체크
+
+        String authNum = UserAuthInfoUtils.generateAuthNumber();
+        String sendPhoneNumber = KOREA_COUNTRY_NUMBER + phoneNumber;
+        String sendMessage = "[셀러툴] 본인확인 인증번호[" + authNum + "]입니다. \"타인 노출 금지\"";
+
+        // SMS 전송
+        Message.creator(new PhoneNumber(sendPhoneNumber), new PhoneNumber(FROM_NUMBER), sendMessage).create();
+
+        String authNumToken = UserInfoAuthTokenUtils.getPhoneAuthNumberJwtToken(authNum, phoneNumber);
+
+        ResponseCookie phoneAuthToken = ResponseCookie.from("st_phone_auth_token", authNumToken)
+                .secure(CustomCookieInterface.SECURE)
+                .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(CustomCookieInterface.PHONE_AUTH_COOKIE_EXPIRATION)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, phoneAuthToken.toString());
+
+        ResponseCookie phoneAuthVerifiedToken = ResponseCookie.from("st_phone_auth_vf_token", null)
+                .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(0)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, phoneAuthVerifiedToken.toString());
+    }
+
+    public void verifyPhoneAuthNumber(HttpServletRequest request, HttpServletResponse response, Map<String, Object> params) {
+        try {
+            String phoneNumber = params.get("phoneNumber").toString();
+            String phoneAuthNumber = params.get("phoneAuthNumber").toString();
+            DataFormatUtils.checkPhoneNumberFormat(phoneNumber);    // 전화번호 형식 체크
+
+            Cookie authCookie = WebUtils.getCookie(request, "st_phone_auth_token");
+
+            String phoneAuthJwtToken = authCookie.getValue();
+            String PHONE_AUTH_JWT_KEY = phoneAuthNumber + PHONE_AUTH_JWT_SECRET;
+
+            // 인증번호 검증
+            Claims claims = Jwts.parser().setSigningKey(PHONE_AUTH_JWT_KEY).parseClaimsJws(phoneAuthJwtToken).getBody();
+
+            if(!claims.get("phoneNumber").equals(phoneNumber)) {
+                throw new UserInfoAuthJwtException("전화번호 인증 요청이 올바르지 않습니다.");
+            }
+
+            // 인증되었다면 새로운 JWT 쿠키 생성
+            String authToken = UserInfoAuthTokenUtils.getPhoneAuthVerifiedJwtToken(phoneNumber);
+
+            ResponseCookie phoneAuthVerifiedToken = ResponseCookie.from("st_phone_auth_vf_token", authToken)
+                    .secure(CustomCookieInterface.SECURE)
+                    .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                    .sameSite("Strict")
+                    .path("/")
+                    .maxAge(CustomCookieInterface.PHONE_AUTH_VF_COOKIE_EXPIRATION)
+                    .build();
+
+            response.addHeader(HttpHeaders.SET_COOKIE, phoneAuthVerifiedToken.toString());
+
+            // st_phone_auth_token 제거
+            ResponseCookie phoneAuthToken = ResponseCookie.from("st_phone_auth_token", null)
+                    .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                    .sameSite("Strict")
+                    .path("/")
+                    .maxAge(0)
+                    .build();
+            response.addHeader(HttpHeaders.SET_COOKIE, phoneAuthToken.toString());
+        } catch (ExpiredJwtException e) {     // 토큰 만료
+            throw new UserInfoAuthJwtException("인증 요청시간이 만료되었습니다.");
+        } catch (NullPointerException e) {   // Phone Auth Number 쿠키가 존재하지 않는다면
+            throw new UserInfoAuthJwtException("전화번호 인증 요청이 올바르지 않습니다.");
+        } catch (IllegalArgumentException e) {
+            throw new UserInfoAuthJwtException("전화번호 인증 요청이 올바르지 않습니다.");
+        } catch (UnsupportedJwtException e) {
+            throw new UserInfoAuthJwtException("전화번호 인증 요청이 올바르지 않습니다.");
+        } catch (MalformedJwtException e) {
+            throw new UserInfoAuthJwtException("전화번호 인증 요청이 올바르지 않습니다.");
+        } catch (SignatureException e) {
+            throw new UserInfoAuthJwtException("전화번호 인증 요청이 올바르지 않습니다.");
+        }
+    }
+
+    public void getEmailAuthNumber(Map<String, Object> params, HttpServletResponse response) throws IOException {
+        Long time = System.currentTimeMillis();
+        String sendEmail = params.get("email").toString();
+        DataFormatUtils.checkEmailFormat(sendEmail);    // 이메일 형식 체크
+
+        String authNum = UserAuthInfoUtils.generateAuthNumber();
+        String sendMessage = "";
+//        String sendMessage = "[셀러툴] 본인확인 인증번호[" + authNum + "]입니다. \"타인 노출 금지\"";
+
+        FileInputStream emailTemplate = new FileInputStream("src/main/resources/static/emailAuthTemplate");
+        sendMessage = IOUtils.toString(emailTemplate, "UTF-8");
+        sendMessage = sendMessage.replaceFirst("------", authNum);
+
+        List<ReceipientForRequest> receipients = new ArrayList<>();
+        ReceipientForRequest receipient = ReceipientForRequest.builder()
+                .address(sendEmail)
+                .type("R")
+                .build();
+        receipients.add(receipient);
+
+        MailRequest mailRequest = MailRequest.builder()
+                .senderAddress(EMAIL_ID)
+                .senderName("Sellertool")
+                .title("[셀러툴] 이메일 인증")
+                .body(sendMessage)
+                .recipients(receipients)
+                .build();
+
+        // 메일 전송
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            String jsonBody = objectMapper.writeValueAsString(mailRequest);
+            HttpHeaders headers = UserAuthInfoUtils.setApiRequestHeader(time);
+
+            HttpEntity<String> body = new HttpEntity<>(jsonBody, headers);
+            RestTemplate restTemplate = new RestTemplate();
+            restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+            restTemplate.postForObject(new URI(MAIL_REQUEST_URL + MAIL_REQUEST_API), body, HashMap.class);
+        } catch(URISyntaxException e) {
+            throw new EmailAuthException("이메일 전송이 불가능합니다.");
+        } catch(JsonProcessingException e) {
+            throw new EmailAuthException("이메일 전송이 불가능합니다.");
+        } catch(InvalidKeyException e) {
+            throw new EmailAuthException("이메일 전송이 불가능합니다.");
+        } catch(NoSuchAlgorithmException e) {
+            throw new EmailAuthException("이메일 전송이 불가능합니다.");
+        } catch(UnsupportedEncodingException e) {
+            throw new EmailAuthException("이메일 전송이 불가능합니다.");
+        } catch(Exception e) {
+            e.printStackTrace();
+            throw new EmailAuthException("이메일 전송이 불가능합니다.");
+        }
+
+        String authNumToken = UserInfoAuthTokenUtils.getEmailAuthNumberJwtToken(authNum, sendEmail);
+
+        ResponseCookie emailAuthToken = ResponseCookie.from("st_email_auth_token", authNumToken)
+                .secure(CustomCookieInterface.SECURE)
+                .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(CustomCookieInterface.EMAIL_AUTH_COOKIE_EXPIRATION)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, emailAuthToken.toString());
+
+        // st_email_auth_vf_token 제거
+        ResponseCookie emailAuthVerifiedToken = ResponseCookie.from("st_email_auth_vf_token", null)
+                .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(0)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, emailAuthVerifiedToken.toString());
+    }
+
+    public void verifyEmailAuthNumber(HttpServletRequest request, HttpServletResponse response, Map<String, Object> params) {
+        try {
+            String email = params.get("email").toString();
+            String emailAuthNumber = params.get("emailAuthNumber").toString();
+            DataFormatUtils.checkEmailFormat(email);    // 이메일 형식 체크
+
+            Cookie authCookie = WebUtils.getCookie(request, "st_email_auth_token");
+
+            String emailAuthJwtToken = authCookie.getValue();
+            String EMAIL_AUTH_JWT_KEY = emailAuthNumber + EMAIL_AUTH_JWT_SECRET;
+
+            // 인증번호 검증
+            Claims claims = Jwts.parser().setSigningKey(EMAIL_AUTH_JWT_KEY).parseClaimsJws(emailAuthJwtToken).getBody();
+
+            if(!claims.get("email").equals(email)) {
+                throw new UserInfoAuthJwtException("인증 요청이 올바르지 않습니다.");
+            }
+
+            // 인증되었다면 새로운 JWT 쿠키 생성
+            String authToken = UserInfoAuthTokenUtils.getEmailAuthVerifiedJwtToken(email);
+
+            ResponseCookie emailAuthVerifiedToken = ResponseCookie.from("st_email_auth_vf_token", authToken)
+                    .secure(CustomCookieInterface.SECURE)
+                    .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                    .sameSite("Strict")
+                    .path("/")
+                    .maxAge(CustomCookieInterface.EMAIL_AUTH_VF_COOKIE_EXPIRATION)
+                    .build();
+
+            response.addHeader(HttpHeaders.SET_COOKIE, emailAuthVerifiedToken.toString());
+
+            // st_email_auth_token 제거
+            ResponseCookie emailAuthToken = ResponseCookie.from("st_email_auth_token", null)
+                    .domain(CustomCookieInterface.COOKIE_DOMAIN)
+                    .sameSite("Strict")
+                    .path("/")
+                    .maxAge(0)
+                    .build();
+            response.addHeader(HttpHeaders.SET_COOKIE, emailAuthToken.toString());
+        } catch (ExpiredJwtException e) {     // 토큰 만료
+            throw new UserInfoAuthJwtException("이메일 인증 요청시간이 만료되었습니다.");
+        } catch (NullPointerException e) {   // Email Auth Number 쿠키가 존재하지 않는다면
+            throw new UserInfoAuthJwtException("이메일 인증 요청이 올바르지 않습니다.");
+        } catch (IllegalArgumentException e) {
+            throw new UserInfoAuthJwtException("이메일 인증 요청이 올바르지 않습니다.");
+        } catch (UnsupportedJwtException e) {
+            throw new UserInfoAuthJwtException("이메일 인증 요청이 올바르지 않습니다.");
+        } catch (MalformedJwtException e) {
+            throw new UserInfoAuthJwtException("이메일 인증 요청이 올바르지 않습니다.");
+        } catch (SignatureException e) {
+            throw new UserInfoAuthJwtException("이메일 인증 요청이 올바르지 않습니다.");
+        }
+    }
+}


### PR DESCRIPTION
#### [ 변경사항 ]

1)
* 유저 정보 관련 인증(이메일, 전화번호 인증)을 UserBusinessService에서 분리했습니다.
* 유저 이메일, 전화번호 인증 로직을 보완했습니다.
* 유저 데이터 조회 시 이메일, 전화번호 쿠키를 모두 제거하고 조회하도록 변경했습니다.

2)
* 회원가입 시 전화번호 입력 항목제거, 이메일 필수값 설정
* 회원정보 수정 시 이메일 필수값, 전화번호 선택값으로 변경

-----